### PR TITLE
conf: Remove mandatory file loading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,8 @@ export default (options: N9ConfOptions = {}) => {
 						fileLoadingError.message
 					}) details: ${JSON.stringify(fileLoadingError)}`,
 				);
+			} else {
+				log(`Missing configuration file ${environment}`);
 			}
 		}
 		// Load its source

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,13 +183,14 @@ export default (options: N9ConfOptions = {}) => {
 		// If config file does not exists
 		if (fileLoadingError) {
 			// Ignore for local.js file
-			if (environment === 'local') break;
-			// throw an error for others
-			throw new Error(
-				`Could not load config file: ${filePath}, ${fileLoadingError.name}(${
-					fileLoadingError.message
-				}) details: ${JSON.stringify(fileLoadingError)}`,
-			);
+			if (environment === 'application') {
+				// throw an error only for default application configuration file
+				throw new Error(
+					`Could not load config file: ${filePath}, ${fileLoadingError.name}(${
+						fileLoadingError.message
+					}) details: ${JSON.stringify(fileLoadingError)}`,
+				);
+			}
 		}
 		// Load its source
 		log(`Loading ${environment} configuration`);


### PR DESCRIPTION
In many cases we are missing the specific namespace env for different projects. On some of them, this is not needed at all. We should remove the mandatory ${NODE_ENV}.ts loading when there is no specific env to load to avoid generating empty files.

The same mechanism applies to java profiles.